### PR TITLE
docs - datadog_monitor module 2 character typo fix

### DIFF
--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -81,7 +81,7 @@ options:
     thresholds:
         description:
             - A dictionary of thresholds by status. This option is only available for service checks and metric alerts. Because each of them can have
-              multiple thresholds, we don't define them directly in the query."]
+              multiple thresholds, we don't define them directly in the query.
         default: {'ok': 1, 'critical': 1, 'warning': 1}
     locked:
         description: ["A boolean indicating whether changes to this monitor should be restricted to the creator or admins."]


### PR DESCRIPTION
##### SUMMARY
Looks like when swapping from single line to multi-line list syntax the trailing quote and bracket got missed.

http://docs.ansible.com/ansible/latest/datadog_monitor_module.html#options

> A dictionary of thresholds by status. This option is only available for service checks and metric alerts. Because each of them can have multiple thresholds, we don't define them directly in the query."]

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
datadog_monitor